### PR TITLE
Add solid Pinterest template

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const centerCropZoom = require('./templatesCrop/01_1_centerCropZoom');
 const quadrat = require('./templates/04_Quadrat');
 const zeitung = require('./templates/05_Zeitung');
 const fresh = require('./templates/06_Fresh');
+const solid = require('./templates/07_solid');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -447,7 +448,44 @@ app.post('/fresh', async (req, res) => {
   } catch (error) {
     console.error('Fehler:', error);
     res.status(500).send('Fehler beim Verarbeiten des Bildes');
-  } 
+  }
+});
+
+// Neue Route: Solid Template
+app.post('/solid', async (req, res) => {
+  const imageUrl = req.body.url;
+  const website = req.body.website || null;
+  let overlayText = req.body.overlay || 'Hello, World!';
+  overlayText = overlayText.toUpperCase();
+
+  console.log('Empfangene Website:', website);
+
+  if (!imageUrl) {
+    return res.status(400).send('Missing "url" in request body');
+  }
+
+  try {
+    const img = await loadImage(imageUrl);
+    const targetWidth = img.width;
+    const targetHeight = img.height;
+
+    const canvas = await solid(img, overlayText, targetWidth, targetHeight, website);
+
+    const filename = `img-solid-${Date.now()}.png`;
+    const savePath = path.join(publicDir, filename);
+    const out = fs.createWriteStream(savePath);
+    const stream = canvas.createPNGStream();
+
+    stream.pipe(out);
+    out.on('finish', () => {
+      const imgUrl = `${req.protocol}://${req.get('host')}/public/${filename}`;
+      res.json({ imgUrl });
+    });
+
+  } catch (error) {
+    console.error('Fehler:', error);
+    res.status(500).send('Fehler beim Verarbeiten des Bildes');
+  }
 });
 
 app.listen(port, () => {

--- a/templates/07_solid.js
+++ b/templates/07_solid.js
@@ -1,0 +1,178 @@
+const { createCanvas } = require('canvas');
+
+module.exports = async function generateSolidTemplate(
+  img,
+  overlayText,
+  targetWidth,
+  targetHeight,
+  website
+) {
+  const canvas = createCanvas(targetWidth, targetHeight);
+  const ctx = canvas.getContext('2d');
+
+  // === Hintergrund in kräftiger Farbe ===
+  ctx.fillStyle = '#FF6F61';
+  ctx.fillRect(0, 0, targetWidth, targetHeight);
+
+  // === Bild als Kreis ===
+  const radius = Math.min(targetWidth, targetHeight) * 0.35;
+  const centerX = targetWidth / 2;
+  const centerY = targetHeight * 0.35;
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+  ctx.closePath();
+  ctx.clip();
+
+  let sSize, sx, sy;
+  if (img.width > img.height) {
+    sSize = img.height;
+    sx = (img.width - sSize) / 2;
+    sy = 0;
+  } else {
+    sSize = img.width;
+    sx = 0;
+    sy = (img.height - sSize) / 2;
+  }
+  ctx.drawImage(img, sx, sy, sSize, sSize, centerX - radius, centerY - radius, radius * 2, radius * 2);
+  ctx.restore();
+
+  // Weißer Ring um das Bild
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = radius * 0.08;
+  ctx.beginPath();
+  ctx.arc(centerX, centerY, radius + ctx.lineWidth / 2, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // === Text vorbereiten ===
+  const maxTextWidth = targetWidth * 0.8;
+  const maxTextBlockHeight = targetHeight * 0.25;
+  const maxLines = 3;
+
+  let chosenFontSize = 16;
+  let lines = [];
+  let lineHeight = 0;
+
+  for (let size = 128; size >= 16; size -= 2) {
+    ctx.font = `900 ${size}px "Open Sans"`;
+    lineHeight = size * 1.2;
+    const testLines = wrapText(ctx, overlayText, maxTextWidth, maxLines);
+    const totalTextHeight = testLines.length * lineHeight;
+    const joined = testLines.join('').replace(/-/g, '').replace(/\s/g, '');
+    const original = overlayText.replace(/-/g, '').replace(/\s/g, '');
+    if (
+      testLines.length <= maxLines &&
+      totalTextHeight <= maxTextBlockHeight &&
+      joined === original
+    ) {
+      chosenFontSize = size;
+      lines = testLines;
+      break;
+    }
+  }
+
+  if (lines.length === 0) {
+    ctx.font = `900 16px "Open Sans"`;
+    lineHeight = 16 * 1.2;
+    lines = wrapText(ctx, overlayText, maxTextWidth, maxLines);
+  }
+
+  ctx.font = `900 ${chosenFontSize}px "Open Sans"`;
+  const totalTextHeight = lines.length * lineHeight;
+  const textY = centerY + radius + 40;
+
+  ctx.fillStyle = '#fff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  lines.forEach((line, index) => {
+    ctx.fillText(line, centerX, textY + index * lineHeight);
+  });
+
+  // === Website unten ===
+  const urlText = website || 'www.superduperseite.de';
+  const urlFontSize = 42;
+  ctx.font = `bold ${urlFontSize}px "Open Sans"`;
+  const urlWidth = ctx.measureText(urlText).width + 60;
+  const urlHeight = urlFontSize * 1.6;
+  const urlX = (targetWidth - urlWidth) / 2;
+  const urlY = targetHeight - urlHeight - 60;
+
+  ctx.fillStyle = 'rgba(255,255,255,0.25)';
+  roundRect(ctx, urlX, urlY, urlWidth, urlHeight, urlHeight / 2);
+  ctx.fill();
+
+  ctx.fillStyle = '#fff';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(urlText.toUpperCase(), targetWidth / 2, urlY + urlHeight / 2);
+
+  return canvas;
+};
+
+// === Hilfsfunktionen ===
+function roundRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function breakLongWord(ctx, word, maxWidth) {
+  let parts = [], current = '';
+  for (let char of word) {
+    const test = current + char;
+    if (ctx.measureText(test).width > maxWidth) {
+      if (current.length > 0) {
+        parts.push(current + '-');
+        current = char;
+      } else {
+        parts.push(char);
+        current = '';
+      }
+    } else {
+      current = test;
+    }
+  }
+  if (current.length > 0) parts.push(current);
+  return parts;
+}
+
+function wrapText(ctx, text, maxWidth, maxLines) {
+  const words = text.split(' ');
+  let lines = [], currentLine = '';
+
+  for (let word of words) {
+    if (ctx.measureText(word).width > maxWidth) {
+      const broken = breakLongWord(ctx, word, maxWidth);
+      for (let part of broken) {
+        if (currentLine.length > 0) {
+          lines.push(currentLine);
+          currentLine = '';
+        }
+        lines.push(part);
+        if (lines.length === maxLines) return lines;
+      }
+      continue;
+    }
+
+    const testLine = currentLine ? currentLine + ' ' + word : word;
+    if (ctx.measureText(testLine).width <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      lines.push(currentLine);
+      currentLine = word;
+      if (lines.length === maxLines) return lines;
+    }
+  }
+
+  if (currentLine && lines.length < maxLines) lines.push(currentLine);
+  return lines;
+}


### PR DESCRIPTION
## Summary
- add vibrant `07_solid` template featuring circular photo, bold background and bottom URL capsule
- wire template into express server with new `/solid` route

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68921bb67718833194c9c9620fffcd7d